### PR TITLE
fix import of LoVe01_TypesAndTerms_DemoMaster as _Demo

### DIFF
--- a/lean/LoVe/LoVe01_TypesAndTerms_Exercise.lean
+++ b/lean/LoVe/LoVe01_TypesAndTerms_Exercise.lean
@@ -1,7 +1,7 @@
 /- Copyright © 2018–2024 Anne Baanen, Alexander Bentkamp, Jasmin Blanchette,
 Johannes Hölzl, and Jannis Limperg. See `LICENSE.txt`. -/
 
-import LoVe.LoVe01_TypesAndTerms_DemoMaster
+import LoVe.LoVe01_TypesAndTerms_Demo
 
 
 /- # LoVe Exercise 1: Types and Terms


### PR DESCRIPTION
As far as I can tell, the module `LoVe.LoVe01_TypesAndTerms_DemoMaster` does not exist. Import `LoVe.LoVe01_TypesAndTerms_Demo` instead.